### PR TITLE
Kimai sso fix

### DIFF
--- a/templates/_keycloak.yml
+++ b/templates/_keycloak.yml
@@ -3,6 +3,61 @@
 id: osss
 realm: osss
 enabled: true
+clientScopes:
+  {{- if .Values.kimai2.enabled }}
+  - name: "role_list"
+    description: "SAML role list"
+    protocol: "saml"
+    attributes:
+      display.on.consent.screen: "true"
+    protocolMappers:
+      - name: "role list"
+        protocol: "saml"
+        protocolMapper: "saml-role-list-mapper"
+        consentRequired: false
+        config:
+          single: "true"
+          attribute.nameformat: "Basic"
+          attribute.name: "Roles"
+  {{- end }}
+roles:
+  client:
+  {{- if .Values.kimai2.enabled }}
+    kimai:
+      - name: "Management"
+        description: "Role for Management in Kimai."
+        composite: false
+        clientRole: true
+        containerId: "kimai"
+      - name: "Admins"
+        description: "Role for Admin in kimai."
+        composite: false
+        clientRole: true
+        containerId: "kimai"
+      - name: "SystemAdmins"
+        description: "Role for System Admin in kimai."
+        composite: false
+        clientRole: true
+        containerId: "kimai"
+  {{- end }}
+groups:
+  {{- if .Values.kimai2.enabled }}
+  - name: "kimai-admin"
+    path: "/kimai-admin"
+    clientRoles:
+      kimai:
+        - "Admins"
+  - name: "kimai-systemadmin"
+    path: "/kimai-systemadmin"
+    clientRoles:
+      kimai:
+        - "SystemAdmins"
+  - name: "kimai-management"
+    path: "/kimai-management"
+    clientRoles:
+      kimai:
+        - "Management"
+  {{- end }}
 components:
   org.keycloak.keys.KeyProvider:
   - id: eedcbe24-d6d6-4620-85d4-c3051ff0ffad
@@ -65,6 +120,10 @@ users:
   username: test
   enabled: true
   emailVerified: true
+  groups:
+  {{- if .Values.kimai2.enabled }}
+  - kimai-management
+  {{- end }}
   credentials:
   - id: pwd
     type: password

--- a/templates/_keycloak.yml
+++ b/templates/_keycloak.yml
@@ -3,23 +3,6 @@
 id: osss
 realm: osss
 enabled: true
-clientScopes:
-  {{- if .Values.kimai2.enabled }}
-  - name: "role_list"
-    description: "SAML role list"
-    protocol: "saml"
-    attributes:
-      display.on.consent.screen: "true"
-    protocolMappers:
-      - name: "role list"
-        protocol: "saml"
-        protocolMapper: "saml-role-list-mapper"
-        consentRequired: false
-        config:
-          single: "true"
-          attribute.nameformat: "Basic"
-          attribute.name: "Roles"
-  {{- end }}
 roles:
   client:
   {{- if .Values.kimai2.enabled }}
@@ -274,7 +257,7 @@ clients:
     saml.server.signature.keyinfo.xmlSigKeyInfoKeyNameTransformer: KEY_ID
   protocolMappers:
   - id: 9f99ca87-46e4-4b32-a6f9-472feef39a2d
-    name: role list
+    name: role_list
     protocol: saml
     protocolMapper: saml-role-list-mapper
     consentRequired: false

--- a/templates/_kimai.yml
+++ b/templates/_kimai.yml
@@ -13,6 +13,7 @@ kimai:
         attribute: Roles
         mapping:
             - { saml: Admins, kimai: ROLE_ADMIN }
+            - { saml: SystemAdmins, kimai: ROLE_SUPER_ADMIN }
             - { saml: Management, kimai: ROLE_TEAMLEAD }
     connection:
         idp:


### PR DESCRIPTION
# Descripción
Problemas de autorización en SSO al ingresar a Kimai mediante Keycloak. 

# Problema

Al intentar loguear, el siguiente error aparece:
![image](https://github.com/renaiss-io/osss/assets/109885056/7f7bad2d-fd5b-46ff-b54e-6dc91d52bc2d)

Desde la consola de Keycloak:

`[2024-06-25T13:22:08.547014+00:00] request.CRITICAL: Uncaught PHP Exception OneLogin\Saml2\ValidationError: "Found an Attribute element with duplicated Name" at Response.php line 827 {"exception":"[object] (OneLogin\\Saml2\\ValidationError(code: 41): Found an Attribute element with duplicated Name at /opt/kimai/vendor/onelogin/php-saml/src/Saml2/Response.php:827)"} {"channel":"request"} ││ localhost:8001 127.0.0.1 - - [25/Jun/2024:14:22:08 +0100] "POST /auth/saml/acs HTTP/1.1" 500 1935 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0"
`

Si revisamos en el payload de SAMLResponse de auth/saml/acs y decodeamos en base64 vemos entre otras cosas:
`<saml:Attribute Name="Role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">view-profile</saml:AttributeValue></saml:Attribute><saml:Attribute Name="Role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">manage-account</saml:AttributeValue></saml:Attribute><saml:Attribute Name="Role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">offline_access</saml:AttributeValue></saml:Attribute><saml:Attribute Name="Role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">
`

# Solución
Podemos observar múltiples atributos "Role" en el payload. Es por esto que el error "Found an Attribute element with duplicated Name" está presente. Para esto debemos crear un role mapper bajo un Client Scope con el Single Role Attribute habilitado. Además, para que funcionen los roles, el nombre de Role Attribute Name debe ser Roles. Si bien estas configuraciones ya estaban presentes, el nombre del role mapper debía ser 'role_list', y en lugar se llamaba 'role list', por lo que no era detectado.

Se agregaron configuraciones adicionales para crear grupos para testear los roles. Además, se agregó el rol SystemAdmin de kimai. Ver descripción de los roles en [Kimai Roles and Permissions](https://www.kimai.org/documentation/permissions.html)