### PR TITLE
Hooks PSQL y MariaDB, SCript para instalar libreria de python

### DIFF
--- a/templates/hooks/mariadb-secret-pre-install.yaml
+++ b/templates/hooks/mariadb-secret-pre-install.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: osss-mariadb-secrets
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+
+data:
+  rootPassword: {{ "kimaiR00tPassw0rd" | b64enc | quote }}
+  username: {{ "kimai" | b64enc | quote }}
+  password: {{ "kimai" | b64enc | quote }}
+  mariadb-root-password: {{ "kimaiR00tPassw0rd" | b64enc | quote }}

--- a/templates/hooks/psql-secret-pre-install.yaml
+++ b/templates/hooks/psql-secret-pre-install.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: osss-psql-secrets
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+
+data:
+  username: testuser
+  password: password
+  postgres-password: password

--- a/values.yaml
+++ b/values.yaml
@@ -349,7 +349,12 @@ odoo:
     type: ClusterIP
 
   customPostInitScripts:
-    python-jose.sh: |
+
+    01_git-installation.sh: |
+      #!/bin/bash
+      apt-get update && apt-get install -y git
+
+    03_python-jose-installation.sh: |
       #!/bin/bash
 
       # Change to the Odoo directory
@@ -360,6 +365,21 @@ odoo:
 
       # Install the required Python package
       pip3 install python-jose || { echo "Failed to install python-jose"; exit 1; }
+
+    02_auth-module-repo-download.sh: |
+      #!/bin/bash
+
+      cd ../opt/bitnami/odoo/addons || { echo "Directory not found"; exit 1; }
+      git clone --branch 17.0 --single-branch "https://github.com/OCA/server-auth.git"
+
+    04_auth-oidc-fix.sh: |
+      #!/bin/bash
+      cd ../opt/bitnami/odoo/addons/server-auth
+      mv auth_oidc ..
+      cd ..
+      rm -rf ./server-auth
+
+    
 
   postgresql:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -31,9 +31,11 @@ postgresql:
   # Override defaults values for the DB
   # TODO: use secrets for DB credentials
   auth:
-    username: testuser
-    password: testpassword
     database: keycloak
+    existingSecret: osss-psql-secrets
+    keys:
+      username: username
+      postgres-password: password
 
   metrics:
     enabled: true
@@ -51,10 +53,13 @@ mariadb:
 
   # TODO: use secrets for DB credentials
   auth:
-    rootPassword: kimaiR00tPassw0rd
     database: kimai
-    username: kimai
-    password: kimai
+    existingSecret: osss-mariadb-secrets
+    keys:
+      username: username
+      password: password
+      rootPassword: rootPassword
+
 
   primary:
     persistence:

--- a/values.yaml
+++ b/values.yaml
@@ -60,13 +60,12 @@ mariadb:
       password: password
       rootPassword: rootPassword
 
-
   primary:
     persistence:
       enabled: true
       storageClass:
       accessModes:
-      - ReadWriteOnce
+        - ReadWriteOnce
       size: 4Gi
 
 ###############################################################
@@ -85,6 +84,8 @@ keycloak:
   auth:
     adminUser: admin
     adminPassword: admin
+    # existingSecret: osss-keycloak-secret-user-credentials
+    # passwordSecretKey: admin-password
 
   # Create preconfigured realm
   keycloakConfigCli:
@@ -127,7 +128,7 @@ promtail:
 
   config:
     clients:
-    - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
+      - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
 
 loki:
   enabled: true
@@ -346,6 +347,19 @@ odoo:
 
   service:
     type: ClusterIP
+
+  customPostInitScripts:
+    python-jose.sh: |
+      #!/bin/bash
+
+      # Change to the Odoo directory
+      cd ../opt/bitnami/odoo/ || { echo "Directory not found"; exit 1; }
+
+      # Activate the virtual environment
+      source venv/bin/activate || { echo "Failed to activate virtual environment"; exit 1; }
+
+      # Install the required Python package
+      pip3 install python-jose || { echo "Failed to install python-jose"; exit 1; }
 
   postgresql:
     enabled: false


### PR DESCRIPTION
Implementar secrets mediante hooks de helm para credenciales de PSQL y MariaDB.
2 hooks pre install de helm para secrets de kubernetes, los cuales contienen las credenciales para las bases de datos mencionadas